### PR TITLE
Escape commit message that includes HTML tag.

### DIFF
--- a/app/views/commits/search.html.erb
+++ b/app/views/commits/search.html.erb
@@ -15,7 +15,7 @@
     <tbody>
       <% @commits.each do |commit| %>
       <tr>
-        <td><%= highlight(commit.message, @keyword.split) %></td>
+        <td><%= highlight(html_escape_once(commit.message), @keyword.split) %></td>
         <td><%= link_to commit.repo_full_name, "https://github.com/#{commit.repo_full_name}", { :target => "_blank" } %></td>
         <td><%= link_to commit.sha[0,7], "https://github.com/#{commit.repo_full_name}/commit/#{commit.sha}", { :target => "_blank" } %></td>
       </tr>


### PR DESCRIPTION
![2015-05-24 11 21 41](https://cloud.githubusercontent.com/assets/9955/7786466/4e2a40a2-020c-11e5-972f-55923731c808.png)

`highlight` returns `html_safe` string, thus we got a input element :dizzy_face: 

(I don't know best practice of escaping html, this is the workaround patch...)