### PR TITLE
Add ElasticSearch analyzer for stemming

### DIFF
--- a/app/helpers/commits_helper.rb
+++ b/app/helpers/commits_helper.rb
@@ -1,2 +1,6 @@
 module CommitsHelper
+  def highlight_message(commit)
+    message = commit.try!(:highlight).try!(:message).try!(:join) || commit.message
+    sanitize(message, tags: %w[mark])
+  end
 end

--- a/app/models/commit.rb
+++ b/app/models/commit.rb
@@ -7,6 +7,13 @@ class Commit < ActiveRecord::Base
           "match": {
             "message": keyword
           }
+        },
+        "highlight": {
+          "pre_tags": ['<mark>'],
+          "post_tags": ['</mark>'],
+          "fields": {
+            "message": {}
+          }
         }
       }
       Commit.__elasticsearch__.search(query)

--- a/app/models/concerns/commit/searchable.rb
+++ b/app/models/concerns/commit/searchable.rb
@@ -9,13 +9,24 @@ module Commit::Searchable
 
     settings index: {
       number_of_shards: 1,
-      number_of_replicas: 0
+      number_of_replicas: 0,
+      analysis: {
+        analyzer: {
+          commit_analyzer: {
+            tokenizer: 'standard',
+            filter: [
+              'lowercase',
+              'porter_stem'
+            ]
+          }
+        }
+      }
     } do
       mapping _source: { enabled: true } do
         indexes :id, type: 'integer', index: 'not_analyzed'
         indexes :repo_full_name, type: 'string'
         indexes :sha, type: 'string', index: 'not_analyzed'
-        indexes :message, type: 'string'
+        indexes :message, type: 'string', analyzer: 'commit_analyzer'
       end
     end
   end

--- a/app/views/commits/search.html.erb
+++ b/app/views/commits/search.html.erb
@@ -15,7 +15,7 @@
     <tbody>
       <% @commits.each do |commit| %>
       <tr>
-        <td><%= highlight(html_escape_once(commit.message), @keyword.split) %></td>
+        <td><%= highlight_message(commit) %></td>
         <td><%= link_to commit.repo_full_name, "https://github.com/#{commit.repo_full_name}", { :target => "_blank" } %></td>
         <td><%= link_to commit.sha[0,7], "https://github.com/#{commit.repo_full_name}/commit/#{commit.sha}", { :target => "_blank" } %></td>
       </tr>


### PR DESCRIPTION
Thanks for the great product!

I've added an analyzer for stemming.  And I've changed a highlighting method to using Elasticsearch feature.

Currently Problem
--------

Currently, I can't find such as `modifying` and `modified` when I searched by `modify`.

screen shot
![1474257451](https://cloud.githubusercontent.com/assets/4361134/18622334/a0ed1830-7e68-11e6-8fc4-ec2e65dccaa8.png)



It isn't useful. 

Fixed behavior
-------

I've fixed the behavior.

screen shot
![1474257312](https://cloud.githubusercontent.com/assets/4361134/18622308/4723f846-7e68-11e6-8fa8-5592c194bdec.png)



Note
-----

For apply the change, you should run the following script.

```ruby
Commit.__elasticsearch__.create_index! force: true
Commit.import
```

I think the above code is too much, but I couldn't find better way than that.


References
----

- [Highlighting | Elasticsearch Reference [2.4] | Elastic](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-highlighting.html)
- [Choosing a Stemmer | Elasticsearch: The Definitive Guide [2.x] | Elastic](https://www.elastic.co/guide/en/elasticsearch/guide/current/choosing-a-stemmer.html)
- [RailsでElasticsearch: ハイライト（Highlight） - Rails Webook](http://ruby-rails.hatenadiary.com/entry/20151025/1445703231)